### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/JetBrains/pycharm.ce.universal.pkg.recipe.yaml
+++ b/JetBrains/pycharm.ce.universal.pkg.recipe.yaml
@@ -131,7 +131,6 @@ Process:
         version: '%version%'
         id: 'pycharm.ce.universal.pkg'
         scripts: '%RECIPE_CACHE_DIR%/Universal/Scripts'
-        options: purge_ds_store
 
   - Processor: PathDeleter
     Arguments:

--- a/Tropy/tropy.pkg.recipe
+++ b/Tropy/tropy.pkg.recipe
@@ -59,8 +59,6 @@
 						<string>%NAME%-%version%</string>
 						<key>id</key>
 						<string>com.tropy.tropy.pkg</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>chown</key>
 						<array>
 							<dict>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._