### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/JetBrains/pycharm.ce.universal.download.recipe.yaml
+++ b/JetBrains/pycharm.ce.universal.download.recipe.yaml
@@ -47,6 +47,8 @@ Process:
     Arguments:
       url: '%match%'
 
+  - Processor: EndOfCheckPhase
+
   - Processor: FileFinder
     Arguments:
       pattern: '%pathname%/*.app'
@@ -63,5 +65,3 @@ Process:
       input_path: '%pathname%/%dmg_found_filename%'
       requirement: 'identifier "com.jetbrains.pycharm.ce" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2ZEFAR8TH3"'
       strict_verification: 'True'
-
-  - Processor: EndOfCheckPhase


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.